### PR TITLE
executeTemplate: allow optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,9 @@ This is my other template:
 And I can call it multiple times:
 {{executeTemplate "custom"}}
 
+Even with a new context:
+{{executeTemplate "custom" 42}}
+
 Or save it to a variable:
 {{$var := executeTemplate "custom"}}
 ```

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -47,11 +47,16 @@ func datacentersFunc(b *Brain, used, missing *dep.Set) func() ([]string, error) 
 }
 
 // executeTemplateFunc executes the given template in the context of the
-// parent. This can be used for nested template definitions.
-func executeTemplateFunc(t *template.Template) func(string) (string, error) {
-	return func(s string) (string, error) {
+// parent. If an argument is specified, it will be used as the context instead.
+// This can be used for nested template definitions.
+func executeTemplateFunc(t *template.Template) func(string, ...interface{}) (string, error) {
+	return func(s string, data ...interface{}) (string, error) {
 		var b bytes.Buffer
-		if err := t.ExecuteTemplate(&b, s, nil); err != nil {
+		var dot interface{}
+		if len(data) != 0 {
+			dot = data[0]
+		}
+		if err := t.ExecuteTemplate(&b, s, dot); err != nil {
 			return "", err
 		}
 		return b.String(), nil

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -510,7 +510,7 @@ func explodeHelper(m map[string]interface{}, k, v, p string) error {
 	return nil
 }
 
-// in seaches for a given value in a given interface.
+// in searches for a given value in a given interface.
 func in(l, v interface{}) (bool, error) {
 	lv := reflect.ValueOf(l)
 	vv := reflect.ValueOf(v)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -580,6 +580,24 @@ func TestTemplate_Execute(t *testing.T) {
 			false,
 		},
 		{
+			"helper_executeTemplate__dot",
+			`{{ define "custom" }}{{ key . }}{{ end }}{{ executeTemplate "custom" "foo" }}`,
+			&ExecuteInput{
+				Brain: func() *Brain {
+					b := NewBrain()
+					d, err := dep.NewKVGetQuery("foo")
+					if err != nil {
+						t.Fatal(err)
+					}
+					d.EnableBlocking()
+					b.Remember(d, "bar")
+					return b
+				}(),
+			},
+			"bar",
+			false,
+		},
+		{
 			"helper_explode",
 			`{{ range $k, $v := tree "list" | explode }}{{ $k }}{{ $v }}{{ end }}`,
 			&ExecuteInput{


### PR DESCRIPTION
While

    {{executeTemplate templateName}}

executes in the context of the parent,

    {{executeTemplate templateName data}}

executes in the context given by the argument "data".